### PR TITLE
Removing apostrophe in GetMaterial description

### DIFF
--- a/LadybugTools_Engine/Query/GetMaterial.cs
+++ b/LadybugTools_Engine/Query/GetMaterial.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.LadybugTools
 {
     public static partial class Query
     {
-        [Description("Get a material object from it's Enum.")]
+        [Description("Get a material object from its Enum.")]
         [Input("material", "An enum value representing a pre-defined ILBTMaterial object.")]
         [Output("material", "A material object to pass into the External Comfort workflow.")]
         public static ILBTMaterial GetMaterial(this Materials material)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #78 

<!-- Add short description of what has been fixed -->

Apostrophe removed.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->