### PR TITLE
Fixed test failure due to mismatch in object properties

### DIFF
--- a/LadybugTools_Engine/Compute/ExternalComfort.cs
+++ b/LadybugTools_Engine/Compute/ExternalComfort.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using BH.oM.LadybugTools;
 using BH.Engine.Serialiser;
 using BH.Engine.Geometry;
+using BH.Engine.Base;
 
 namespace BH.Engine.LadybugTools
 {
@@ -86,6 +87,12 @@ namespace BH.Engine.LadybugTools
 
             string output = env.RunPythonString(pythonScript).Trim().Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).Last();
 
+            if (output.Substring(0, 12).Contains("error"))
+            {
+                BH.Engine.Base.Compute.RecordError(Serialiser.Convert.FromJson(output).PropertyValue("error").ToString());
+                return null;
+            }
+            
             // reload from Python results
             return (ExternalComfort)Serialiser.Convert.FromJson(output);
         }

--- a/LadybugTools_Engine/Compute/SimulationResult.cs
+++ b/LadybugTools_Engine/Compute/SimulationResult.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using System.IO;
 using BH.oM.LadybugTools;
 using BH.Engine.Serialiser;
+using BH.Engine.Base;
 
 namespace BH.Engine.LadybugTools
 {
@@ -91,6 +92,12 @@ namespace BH.Engine.LadybugTools
             });
             string output = env.RunPythonString(pythonScript).Trim().Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).Last();
 
+            if (output.Substring(0, 12).Contains("error"))
+            {
+                BH.Engine.Base.Compute.RecordError(Serialiser.Convert.FromJson(output).PropertyValue("error").ToString());
+                return null;
+            }
+            
             // reload from Python results
             return (SimulationResult)Serialiser.Convert.FromJson(output);
         }

--- a/LadybugTools_Engine/Create/Typology.cs
+++ b/LadybugTools_Engine/Create/Typology.cs
@@ -77,7 +77,7 @@ namespace BH.Engine.LadybugTools
 
             return new Typology()
             {
-                Name = name,
+                Name = rtnName,
                 Shelters = shelters.Where(s => s != null).ToList(),
                 EvaporativeCoolingEffect = Enumerable.Repeat(evaporativeCoolingEffect, 8760).ToList(),
                 WindSpeedMultiplier = Enumerable.Repeat(windSpeedMultiplier, 8760).ToList(),

--- a/LadybugTools_oM/SimulationResult.cs
+++ b/LadybugTools_oM/SimulationResult.cs
@@ -39,47 +39,27 @@ namespace BH.oM.LadybugTools
 
         // simulated properties
         [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedDownDirectIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedDownDiffuseIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedDownTotalIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
         public virtual CustomObject ShadedDownTemperature { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedUpDiffuseIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedUpDirectIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedUpTotalIrradiance { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
         public virtual CustomObject ShadedUpTemperature { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedLongwaveMeanRadiantTemperature { get; set; } = new CustomObject();
+        public virtual CustomObject ShadedRadiantTemperature { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
-        public virtual CustomObject ShadedShortwaveMeanRadiantTemperature { get; set; } = new CustomObject();
+        public virtual CustomObject ShadedLongwaveMeanRadiantTemperatureDelta { get; set; } = new CustomObject();
+        [Description("The simulated property from this object.")]
+        public virtual CustomObject ShadedShortwaveMeanRadiantTemperatureDelta { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
         public virtual CustomObject ShadedMeanRadiantTemperature { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedDownDiffuseIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedDownDirectIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedDownTotalIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
         public virtual CustomObject UnshadedDownTemperature { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedUpDiffuseIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedUpDirectIrradiance { get; set; } = new CustomObject();
-        [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedUpTotalIrradiance { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
         public virtual CustomObject UnshadedUpTemperature { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedLongwaveMeanRadiantTemperature { get; set; } = new CustomObject();
+        public virtual CustomObject UnshadedRadiantTemperature { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
-        public virtual CustomObject UnshadedShortwaveMeanRadiantTemperature { get; set; } = new CustomObject();
+        public virtual CustomObject UnshadedLongwaveMeanRadiantTemperatureDelta { get; set; } = new CustomObject();
+        [Description("The simulated property from this object.")]
+        public virtual CustomObject UnshadedShortwaveMeanRadiantTemperatureDelta { get; set; } = new CustomObject();
         [Description("The simulated property from this object.")]
         public virtual CustomObject UnshadedMeanRadiantTemperature { get; set; } = new CustomObject();
     }


### PR DESCRIPTION
… to avoid failure in passing data between languages

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Failure in testing of code passed between BHoM/C# and Python where objects hadn't been fully updated to match new schema. Minor fix to ensure that properties can be populated to stop failure in this process.


### Test files
<!-- Link to test files to validate the proposed changes -->
LBT_Tk test script should now function fully, so I'd suggest using that to test as otherwise it returns a failure.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->