### PR TITLE
Changed paths from C:/ProgramData to generic ProgramData folder

### DIFF
--- a/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
+++ b/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.LadybugTools
         public static PythonEnvironment InstallPythonEnv_LBT(bool run = false, bool reinstall = false)
         {
             // check if referenced Python is installed
-            string referencedExecutable = @"C:\Program Files\ladybug_tools\python\python.exe";
+            string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
 
             if (!Query.IsPollinationInstalled())
             {

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/__init__.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/__init__.py
@@ -1,16 +1,16 @@
 """Root for the bhom subpackage."""
 
-#from pathlib import Path  # pylint: disable=E0401
+from pathlib import Path  # pylint: disable=E0401
 from os import path
 
 from win32api import HIWORD, LOWORD, GetFileVersionInfo
 
-BHOM_ASSEMBLIES_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Assemblies")
-BHOM_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM")
-BHOM_LOG_FOLDER = path.expandvars("%PROGRAMDATA%/BHoM/Logs")
+BHOM_ASSEMBLIES_DIRECTORY = Path(path.expandvars("%PROGRAMDATA%/BHoM/Assemblies"))
+BHOM_DIRECTORY = Path(path.expandvars("%PROGRAMDATA%/BHoM"))
+BHOM_LOG_FOLDER = Path(path.expandvars("%PROGRAMDATA%/BHoM/Logs"))
 
-PYTHON_CODE_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonCode")
-PYTHON_ENVIRONMENTS_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonEnvironments")
+PYTHON_CODE_DIRECTORY = Path(path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonCode"))
+PYTHON_ENVIRONMENTS_DIRECTORY = Path(path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonEnvironments"))
 
 TOOLKIT_NAME = "LadybugTools_Toolkit"
 

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/__init__.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/__init__.py
@@ -1,17 +1,16 @@
 """Root for the bhom subpackage."""
 
-from pathlib import Path  # pylint: disable=E0401
+#from pathlib import Path  # pylint: disable=E0401
+from os import path
 
 from win32api import HIWORD, LOWORD, GetFileVersionInfo
 
-BHOM_ASSEMBLIES_DIRECTORY = Path("C:/ProgramData/BHoM/Assemblies")
-BHOM_DIRECTORY = Path("C:/ProgramData/BHoM")
-BHOM_LOG_FOLDER = Path("C:/ProgramData/BHoM/Logs")
+BHOM_ASSEMBLIES_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Assemblies")
+BHOM_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM")
+BHOM_LOG_FOLDER = path.expandvars("%PROGRAMDATA%/BHoM/Logs")
 
-PYTHON_CODE_DIRECTORY = Path("C:/ProgramData/BHoM/Extensions/PythonCode")
-PYTHON_ENVIRONMENTS_DIRECTORY = Path(
-    "C:/ProgramData/BHoM/Extensions/PythonEnvironments"
-)
+PYTHON_CODE_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonCode")
+PYTHON_ENVIRONMENTS_DIRECTORY = path.expandvars("%PROGRAMDATA%/BHoM/Extensions/PythonEnvironments")
 
 TOOLKIT_NAME = "LadybugTools_Toolkit"
 

--- a/LadybugTools_Engine/Query/IsPollinationInstalled.cs
+++ b/LadybugTools_Engine/Query/IsPollinationInstalled.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.LadybugTools
         public static bool IsPollinationInstalled(string targetPollinationVersion = "1.38.104", bool includeBuildNumber = false)
         {
             // check if referenced Python is installed
-            string referencedExecutable = @"C:\Program Files\ladybug_tools\python\python.exe";
+            string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
             if (!File.Exists(referencedExecutable))
             {
                 Base.Compute.RecordError($"Could not find referenced python executable at {referencedExecutable}. Please install Pollination version {targetPollinationVersion} and try again.");
@@ -49,7 +49,7 @@ namespace BH.Engine.LadybugTools
             }
 
             // obtain version of pollination installed
-            string referencedUninstaller = @"C:\Program Files\ladybug_tools\uninstall.exe";
+            string referencedUninstaller = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\uninstall.exe";
             FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(referencedUninstaller);
             if (includeBuildNumber && (versionInfo.ProductVersion != targetPollinationVersion))
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #137 

<!-- Add short description of what has been fixed -->
Used os.path to get the common `ProgramData` folder rather than specifically referring to `C:/ProgramData` in python, and used `System.Environment.GetFolderPath()` to get the path to Program Files when installing python and checking pollination install

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->