### PR TITLE
Added version check to existing environment query

### DIFF
--- a/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
+++ b/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
@@ -42,9 +42,7 @@ namespace BH.Engine.LadybugTools
 
             // check if referenced Python is installed, and get executable and version if it is
             if (!Query.IsPollinationInstalled())
-            {
                 return null;
-            }
             string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
             PythonVersion pythonVersion = Python.Query.Version(referencedExecutable);
 

--- a/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
+++ b/LadybugTools_Engine/Compute/InstallPythonEnv_LBT.cs
@@ -37,43 +37,31 @@ namespace BH.Engine.LadybugTools
         [Output("env", "The LadybugTools_Toolkit Python Environment, with BHoM code accessible.")]
         public static PythonEnvironment InstallPythonEnv_LBT(bool run = false, bool reinstall = false)
         {
-            // check if referenced Python is installed
-            string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
+            if (!run)
+                return null;
 
+            // check if referenced Python is installed, and get executable and version if it is
             if (!Query.IsPollinationInstalled())
             {
                 return null;
             }
-
-            if (!run)
-                return null;
-
-            // find out whether this environment already exists
-            bool exists = Python.Query.VirtualEnvironmentExists(Query.ToolkitName());
-
-            if (reinstall)
-                Python.Compute.RemoveVirtualEnvironment(Query.ToolkitName());
-
-            // obtain python version
+            string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
             PythonVersion pythonVersion = Python.Query.Version(referencedExecutable);
 
-            // create virtualenvironment
-            PythonEnvironment env = Python.Compute.VirtualEnvironment(version: pythonVersion, name: Query.ToolkitName(), reload: true);
+            // check if environment already exists. If it does, and no reinstall requested, load it
+            bool exists = Python.Query.VirtualEnvironmentExists(envName: Query.ToolkitName(), pythonVersion: pythonVersion);
+            if (run && exists && !reinstall)
+                return Python.Compute.VirtualEnvironment(version: pythonVersion, name: Query.ToolkitName(), reload: true);
 
-            // return null if environment could not be created/loaded
-            if (env == null)
-                return null;
+            // create environment from scratch
+            PythonEnvironment env = Python.Compute.VirtualEnvironment(version: pythonVersion, name: Query.ToolkitName(), reload: false);
 
-            // install packages if this is a reinstall, or the environment did not originally exist
-            if (reinstall || !exists)
-            {
-                // install local package
-                env.InstallPackageLocal(Path.Combine(Python.Query.DirectoryCode(), Query.ToolkitName()));
+            // install local package
+            env.InstallPackageLocal(Path.Combine(Python.Query.DirectoryCode(), Query.ToolkitName()));
 
-                // create requiremetns from referenced executable
-                string requirementsTxt = Python.Compute.RequirementsTxt(referencedExecutable, Path.Combine(Python.Query.DirectoryEnvironments(), $"requirements_{Query.ToolkitName()}.txt"));
-                env.InstallRequirements(requirementsTxt);
-            }
+            // create requirements from referenced executable
+            string requirementsTxt = Python.Compute.RequirementsTxt(referencedExecutable, Path.Combine(Python.Query.DirectoryEnvironments(), $"requirements_{Query.ToolkitName()}.txt"));
+            env.InstallRequirements(requirementsTxt);
 
             return env;
         }

--- a/LadybugTools_Engine/LadybugTools_Engine.csproj
+++ b/LadybugTools_Engine/LadybugTools_Engine.csproj
@@ -85,11 +85,11 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="xcopy &quot;$(ProjectDir)Convert\System.Web.Extensions.dll&quot; &quot;C:\\ProgramData\\BHoM\\Assemblies&quot; /Y&#xD;&#xA;&#xD;&#xA;if not exist &quot;C:\ProgramData\BHoM\Extensions\PythonEnvironments&quot; mkdir &quot;C:\ProgramData\BHoM\Extensions\PythonEnvironments&quot;&#xD;&#xA;if not exist &quot;C:\ProgramData\BHoM\Extensions\PythonCode&quot; mkdir &quot;C:\ProgramData\BHoM\Extensions\PythonCode&quot;&#xD;&#xA;      &#xD;&#xA;if exist &quot;C:\ProgramData\BHoM\Extensions\PythonCode\$(SolutionName)&quot; rmdir &quot;C:\ProgramData\BHoM\Extensions\PythonCode\$(SolutionName)&quot; /S /Q&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Extensions\PythonCode\$(SolutionName)&quot;&#xD;&#xA;&#xD;&#xA;robocopy &quot;$(ProjectDir)Python&quot; &quot;C:\ProgramData\BHoM\Extensions\PythonCode\$(SolutionName)&quot; /mir /xf &quot;*.pyc&quot; &quot;*.ipynb&quot; /xd &quot;__*__&quot; &quot;.*&quot; &gt; output.log&#xD;&#xA;del output.log" />
+    <Exec Command="xcopy $(ProjectDir)Convert\System.Web.Extensions.dll $(ProgramData)\BHoM\Assemblies /Y&#xD;&#xA;&#xD;&#xA;if not exist $(ProgramData)\BHoM\Extensions\PythonEnvironments mkdir $(ProgramData)\BHoM\Extensions\PythonEnvironments&#xD;&#xA;if not exist $(ProgramData)\BHoM\Extensions\PythonCode mkdir $(ProgramData)\BHoM\Extensions\PythonCode&#xD;&#xA;      &#xD;&#xA;if exist $(ProgramData)\BHoM\Extensions\PythonCode\$(SolutionName) rmdir $(ProgramData)\BHoM\Extensions\PythonCode\$(SolutionName) /S /Q&#xD;&#xA;mkdir $(ProgramData)\BHoM\Extensions\PythonCode\$(SolutionName)&#xD;&#xA;&#xD;&#xA;robocopy $(ProjectDir)Python $(ProgramData)\BHoM\Extensions\PythonCode\$(SolutionName) /mir /xf &quot;*.pyc&quot; &quot;*.ipynb&quot; /xd &quot;__*__&quot; &quot;.*&quot; &gt; output.log&#xD;&#xA;del output.log" />
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\\ProgramData\\BHoM\\Assemblies&quot; /Y" />
+    <Exec Command="xcopy $(TargetDir)$(TargetFileName) $(ProgramData)\BHoM\Assemblies /Y" />
   </Target>
 
 </Project>

--- a/LadybugTools_Engine/Query/IsPollinationInstalled.cs
+++ b/LadybugTools_Engine/Query/IsPollinationInstalled.cs
@@ -35,10 +35,9 @@ namespace BH.Engine.LadybugTools
     public static partial class Query
     {
         [Description("Return True if Pollination is installed to the currently supported version.")]
-        [Input("targetPollinationVersion", "The target Pollination version that BHoM currently supports. Default is 1.35.14 which has an uninstaller ProductVersion of 1.38.104, which is the number that is checked against on the uninstaller that comes bundled with Pollincation.")]
-        [Input("includeBuildNumber", "If true, the build number (the third number in the X.X.X ProductVersion) will be included in the comparison.")]
+        [Input("targetPollinationVersion", "The target Pollination version that BHoM currently supports.")]
         [Output("bool", "True if Pollination is installed to the currently supported version.")]
-        public static bool IsPollinationInstalled(string targetPollinationVersion = "1.38.104", bool includeBuildNumber = false)
+        public static bool IsPollinationInstalled(string targetPollinationVersion = "1.35.14")
         {
             // check if referenced Python is installed
             string referencedExecutable = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\python\python.exe";
@@ -49,24 +48,12 @@ namespace BH.Engine.LadybugTools
             }
 
             // obtain version of pollination installed
-            string referencedUninstaller = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\ladybug_tools\uninstall.exe";
+            string referencedUninstaller = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles) + @"\pollination\uninstall.exe";
             FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(referencedUninstaller);
-            if (includeBuildNumber && (versionInfo.ProductVersion != targetPollinationVersion))
+            if (versionInfo.ProductVersion != targetPollinationVersion)
             {
                 Base.Compute.RecordError($"Pollination version installed ({versionInfo.ProductVersion}) is not the same as the version required for this code to function correctly ({targetPollinationVersion}).");
                 return false;
-            }
-
-            // check that version matches the target version
-            int major = int.Parse(targetPollinationVersion.Split('.')[0]);
-            int minor = int.Parse(targetPollinationVersion.Split('.')[1]);
-            if (versionInfo.ProductMajorPart != major || versionInfo.ProductMinorPart != minor)
-            {
-                if (versionInfo.ProductVersion != targetPollinationVersion)
-                {
-                    Base.Compute.RecordError($"Pollination version installed ({versionInfo.ProductVersion}) is not the same as the version required for this code to function correctly ({targetPollinationVersion}).");
-                    return false;
-                }
             }
 
             return true;

--- a/LadybugTools_oM/LadybugTools_oM.csproj
+++ b/LadybugTools_oM/LadybugTools_oM.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="xcopy $(TargetDir)$(TargetFileName) $(ProgramData)\BHoM\Assemblies /Y" />
   </Target>
 
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Python_Toolkit/pull/126
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #150

<!-- Add short description of what has been fixed -->
Pollination version now obtained from a different file which makes ascertaining version installed a bit simpler. Also, logic for returning an existing environment modified to incorporate changes in Python_Toolkit (issue above). This _should_ partially stop some of the weird issues where users have differing versions of tools installed that makes behaviour less predictable, and align all using one single version - forcing a reinstall of the target software if required.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->