### PR TITLE
Adapter: made LBT PythonEnvironment a private property

### DIFF
--- a/LadybugTools_Adapter/AdapterActions/Execute.cs
+++ b/LadybugTools_Adapter/AdapterActions/Execute.cs
@@ -74,7 +74,6 @@ namespace BH.Adapter.LadybugTools
 
         private List<object> RunCommand(GetMaterialCommand command)
         {
-            PythonEnvironment env = Engine.LadybugTools.Compute.InstallPythonEnv_LBT(true);
             LadybugConfig config = new LadybugConfig()
             {
                 JsonFile = new FileSettings()
@@ -88,7 +87,7 @@ namespace BH.Adapter.LadybugTools
             {
                 string script = Path.Combine(Engine.Python.Query.DirectoryCode(), "LadybugTools_Toolkit\\src\\ladybugtools_toolkit\\bhom\\wrapped", "get_material.py");
 
-                string cmdCommand = $"{env.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
+                string cmdCommand = $"{m_environment.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
 
                 Engine.Python.Compute.RunCommandStdout(command: cmdCommand, hideWindows: true);
             }
@@ -103,7 +102,6 @@ namespace BH.Adapter.LadybugTools
 
         private List<object> RunCommand(GetTypologyCommand command)
         {
-            PythonEnvironment env = Engine.LadybugTools.Compute.InstallPythonEnv_LBT(true);
             LadybugConfig config = new LadybugConfig()
             {
                 JsonFile = new FileSettings()
@@ -117,7 +115,7 @@ namespace BH.Adapter.LadybugTools
             {
                 string script = Path.Combine(Engine.Python.Query.DirectoryCode(), "LadybugTools_Toolkit\\src\\ladybugtools_toolkit\\bhom\\wrapped", "get_typology.py");
 
-                string cmdCommand = $"{env.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
+                string cmdCommand = $"{m_environment.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
 
                 Engine.Python.Compute.RunCommandStdout(command: cmdCommand, hideWindows: true);
             }
@@ -179,12 +177,11 @@ namespace BH.Adapter.LadybugTools
             // push object to json file
             Push(new List<SimulationResult>() { simulationResult }, actionConfig: config);
 
-            // locate the Python executable and file containing the simulation code
-            PythonEnvironment env = Engine.LadybugTools.Compute.InstallPythonEnv_LBT(true);
+            // locate the Python file containing the simulation code
             string script = Path.Combine(Engine.Python.Query.DirectoryCode(), "LadybugTools_Toolkit\\src\\ladybugtools_toolkit\\bhom\\wrapped", "simulation_result.py");
 
             // run the simulation
-            string cmdCommand = $"{env.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
+            string cmdCommand = $"{m_environment.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
             Engine.Python.Compute.RunCommandStdout(command: cmdCommand, hideWindows: true);
 
             // reload from Python results
@@ -232,12 +229,11 @@ namespace BH.Adapter.LadybugTools
             // push objects to json file
             Push(new List<ExternalComfort>() { externalComfort }, actionConfig: config);
 
-            // locate the Python executable and file containing the simulation code
-            PythonEnvironment env = Engine.LadybugTools.Compute.InstallPythonEnv_LBT(true);
+            // locate the Python file containing the simulation code
             string script = Path.Combine(Engine.Python.Query.DirectoryCode(), "LadybugTools_Toolkit\\src\\ladybugtools_toolkit\\bhom\\wrapped", "external_comfort.py");
 
             // run the calculation
-            string cmdCommand = $"{env.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
+            string cmdCommand = $"{m_environment.Executable} {script} -j \"{config.JsonFile.GetFullFileName()}\"";
             Engine.Python.Compute.RunCommandStdout(command: cmdCommand, hideWindows: true);
 
             // reload from Python results

--- a/LadybugTools_Adapter/LadybugTools_Adapter.cs
+++ b/LadybugTools_Adapter/LadybugTools_Adapter.cs
@@ -22,7 +22,7 @@
 
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
-
+using BH.oM.Python;
 
 namespace BH.Adapter.LadybugTools
 {
@@ -33,7 +33,11 @@ namespace BH.Adapter.LadybugTools
         public LadybugToolsAdapter()
         {
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
+
+            //get the base python environment first, as LBT is dependant on it.
+            BH.Engine.Python.Compute.BasePythonEnvironment(run: true);
+            m_environment = BH.Engine.LadybugTools.Compute.InstallPythonEnv_LBT(run: true);
         }
+        private readonly PythonEnvironment m_environment;
     }
 }
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #171 

<!-- Add short description of what has been fixed -->
Added private `m_environment` property to `LadybugToolsAdapter` and updated usage in execute commands.
Also install BasePythonEnvironment before LBT environment for better UX

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->