### PR TITLE
Fixed heatplot method not returning base64 encoded image

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
@@ -21,7 +21,7 @@ def main(epw_file: str, data_type_key: str, colour_map: str, save_path:str = Non
         epw = EPW(epw_file)
         coll = HourlyContinuousCollection.from_dict([a for a in epw.to_dict()["data_collections"] if a["header"]["data_type"]["name"] == data_type_key][0])
         fig = heatmap(collection_to_series(coll), cmap=colour_map).get_figure()
-        if save_path == None:
+        if save_path == None or save_path == "":
             base64 = figure_to_base64(fig,html=False)
             print(base64)
         else:


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #174 

<!-- Add short description of what has been fixed -->
`save_path` variable now includes a check for empty string including `None`

### Test files
<!-- Link to test files to validate the proposed changes -->
[LBT_Plots.zip](https://github.com/BHoM/LadybugTools_Toolkit/files/14521354/LBT_Plots.zip)
change the save directory (preset as C:/github/0_temp/temp.png) to an empty string or remove the panel entirely, and run the `HeatPlotCommand`

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->