### PR TITLE
Added EPW comparison plot methods

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/epw.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/epw.py
@@ -51,6 +51,39 @@ from .header import header_to_string
 from .location import average_location, location_to_string
 
 
+EPW_PROPERTIES = [
+    "aerosol_optical_depth",
+    "albedo",
+    "atmospheric_station_pressure",
+    "ceiling_height",
+    "days_since_last_snowfall",
+    "dew_point_temperature",
+    "diffuse_horizontal_illuminance",
+    "diffuse_horizontal_radiation",
+    "direct_normal_illuminance",
+    "direct_normal_radiation",
+    "dry_bulb_temperature",
+    "extraterrestrial_direct_normal_radiation",
+    "extraterrestrial_horizontal_radiation",
+    "global_horizontal_illuminance",
+    "global_horizontal_radiation",
+    "horizontal_infrared_radiation_intensity",
+    "liquid_precipitation_depth",
+    "liquid_precipitation_quantity",
+    "opaque_sky_cover",
+    "precipitable_water",
+    "present_weather_codes",
+    "present_weather_observation",
+    "relative_humidity",
+    "snow_depth",
+    "total_sky_cover",
+    "visibility",
+    "wind_direction",
+    "wind_speed",
+    "years",
+    "zenith_luminance",
+    ]
+
 @bhom_analytics()
 def epw_to_dataframe(
     epw: EPW, include_additional: bool = False, **kwargs
@@ -72,38 +105,7 @@ def epw_to_dataframe(
             A Pandas DataFrame containing the source EPW data.
     """
 
-    properties = [
-        "aerosol_optical_depth",
-        "albedo",
-        "atmospheric_station_pressure",
-        "ceiling_height",
-        "days_since_last_snowfall",
-        "dew_point_temperature",
-        "diffuse_horizontal_illuminance",
-        "diffuse_horizontal_radiation",
-        "direct_normal_illuminance",
-        "direct_normal_radiation",
-        "dry_bulb_temperature",
-        "extraterrestrial_direct_normal_radiation",
-        "extraterrestrial_horizontal_radiation",
-        "global_horizontal_illuminance",
-        "global_horizontal_radiation",
-        "horizontal_infrared_radiation_intensity",
-        "liquid_precipitation_depth",
-        "liquid_precipitation_quantity",
-        "opaque_sky_cover",
-        "precipitable_water",
-        "present_weather_codes",
-        "present_weather_observation",
-        "relative_humidity",
-        "snow_depth",
-        "total_sky_cover",
-        "visibility",
-        "wind_direction",
-        "wind_speed",
-        "years",
-        "zenith_luminance",
-    ]
+    properties = EPW_PROPERTIES
 
     all_series = []
     for prop in properties:
@@ -239,38 +241,7 @@ def epw_from_dataframe(
         epw_obj.comments_2 = comments_2
 
     # Assign data to the EPW
-    properties = [
-        "aerosol_optical_depth",
-        "albedo",
-        "atmospheric_station_pressure",
-        "ceiling_height",
-        "days_since_last_snowfall",
-        "dew_point_temperature",
-        "diffuse_horizontal_illuminance",
-        "diffuse_horizontal_radiation",
-        "direct_normal_illuminance",
-        "direct_normal_radiation",
-        "dry_bulb_temperature",
-        "extraterrestrial_direct_normal_radiation",
-        "extraterrestrial_horizontal_radiation",
-        "global_horizontal_illuminance",
-        "global_horizontal_radiation",
-        "horizontal_infrared_radiation_intensity",
-        "liquid_precipitation_depth",
-        "liquid_precipitation_quantity",
-        "opaque_sky_cover",
-        "precipitable_water",
-        "present_weather_codes",
-        "present_weather_observation",
-        "relative_humidity",
-        "snow_depth",
-        "total_sky_cover",
-        "visibility",
-        "wind_direction",
-        "wind_speed",
-        "years",
-        "zenith_luminance",
-    ]
+    properties = EPW_PROPERTIES
 
     for prop in properties:
         try:

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
@@ -28,6 +28,9 @@ def compare_epw_key_hist(
             a matplotlib Axes object that contains the plotted histogram.
     """
 
+    # done so that keys like "Dry Bulb Temperature" are valid
+    key = key.lower().replace(" ", "_")
+
     if key not in EPW_PROPERTIES:
         raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")
 
@@ -63,6 +66,9 @@ def compare_epw_key_line(
         plt.Axes:
             a matplotlib Axes object that contains the plotted line chart.
     """
+    
+    # done so that keys like "Dry Bulb Temperature" are valid
+    key = key.lower().replace(" ", "_")
 
     if key not in EPW_PROPERTIES:
         raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
@@ -12,6 +12,21 @@ def compare_epw_key_hist(
     key: str,
     bins: list[float] = None,
     ) -> plt.Axes:
+    """Compare two or more EPW files against each other based upon a single key, to create a histogram plot.
+    
+    Args:
+        epws (list[EPW]):
+            list of epw objects to compare
+        key (str):
+            epw property to use for comparison
+        bins (list[float]):
+            list of bins to use for the histogram
+            defaults to None, which causes the plot to create its own bins using np.linspace between the min and max values.
+
+    Returns:
+        plt.Axes:
+            a matplotlib Axes object that contains the plotted histogram.
+    """
 
     if key not in EPW_PROPERTIES:
         raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")
@@ -36,6 +51,18 @@ def compare_epw_key_line(
     epws: list[EPW],
     key: str,
     ):
+    """Compare two or more EPW files against each other based upon a single key, to create a line plot.
+    
+    Args:
+        epws (list[EPW]):
+            list of epw objects to compare
+        key (str):
+            epw property to use for comparison
+
+    Returns:
+        plt.Axes:
+            a matplotlib Axes object that contains the plotted line chart.
+    """
 
     if key not in EPW_PROPERTIES:
         raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/compare.py
@@ -1,0 +1,48 @@
+﻿from ladybug.epw import EPW, EPWFields
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from ladybugtools_toolkit.ladybug_extension.epw import collection_to_series, EPW_PROPERTIES
+from ladybugtools_toolkit.bhom.analytics import bhom_analytics
+
+@bhom_analytics()
+def compare_epw_key_hist(
+    epws: list[EPW],
+    key: str,
+    bins: list[float] = None,
+    ) -> plt.Axes:
+
+    if key not in EPW_PROPERTIES:
+        raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")
+
+    serieses = [collection_to_series(getattr(i, key)) for i in epws]
+    df = pd.concat(serieses, axis=1, keys=[Path(epw.file_path).stem for epw in epws])
+    
+    if bins is None:
+        bins = np.linspace(df.values.min(), df.values.max(), 31)
+    elif len(bins) == 0:
+        bins = np.linspace(df.values.min(), df.values.max(), 31)
+
+    fig, ax = plt.subplots(1, 1, figsize=(12, 5))
+    ax.hist(df.values, bins=bins, label = df.columns, density=False)
+    ax.legend()
+    ax.set_ylabel("Number of hours (/8760)")
+    ax.set_xlabel(serieses[0].name)
+    return ax
+
+@bhom_analytics()
+def compare_epw_key_line(
+    epws: list[EPW],
+    key: str,
+    ):
+
+    if key not in EPW_PROPERTIES:
+        raise ValueError(f"The key: {key}, is not a valid epw key. Please select one from the list in: ladybugtools_toolkit.ladybug_extension.epw EPW_PROPERTIES")
+
+    serieses = [collection_to_series(getattr(i, key)) for i in epws]
+    df = pd.concat(serieses, axis=1, keys=[Path(epw.file_path).stem for epw in epws])
+
+    fix, ax = plt.subplots(1, 1, figsize=(12, 5))
+    df.plot(ax=ax, ylabel=serieses[0].name)
+    return ax


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #86 

<!-- Add short description of what has been fixed -->
Added two methods that plot charts that can be used to compare multiple EPW files like this:
`compare_epw_key_hist`
![image](https://github.com/BHoM/LadybugTools_Toolkit/assets/142492848/cb4311a3-8c99-4afb-a229-5811380db51c)
`compare_epw_key_line`
![image](https://github.com/BHoM/LadybugTools_Toolkit/assets/142492848/9885d9d5-62b7-4e5d-9b11-c5cfc662c834)

Also created a list that can be used to check validity of epw keys python-side

### Test files
<!-- Link to test files to validate the proposed changes -->
Test with jupyter, trying out multiple keys and seeing if they work. It will accept keys in the following forms(dry bulb temperature as example):
* dry bulb temperature
* dry_bulb_temperature

and this will match case-insensitive

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
I will open a new issue to cover creation of wrappers for use with the `LadybugTools_Adapter`