### PR TITLE
Fixed deprecation warnings for python unit tests

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/shelter.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/shelter.py
@@ -50,7 +50,7 @@ class TreeShelter(Enum):
         ) as fp:
             tree_config = json.load(fp)[self.name]
 
-        idx = pd.date_range("2017-01-01", periods=8760, freq="60T")
+        idx = pd.date_range("2017-01-01", periods=8760, freq="60min")
         if tree_config["deciduous"]:
             vals = np.stack(
                 [

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/datacollection.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/datacollection.py
@@ -440,7 +440,7 @@ def to_hourly(
 
     series = collection_to_series(collection)
     annual_hourly_index = pd.date_range(
-        f"{series.index[0].year}-01-01", periods=8760, freq="H"
+        f"{series.index[0].year}-01-01", periods=8760, freq="h"
     )
     series_annual = series.reindex(annual_hourly_index)
     series_annual[series_annual.index[-1]] = series_annual[series_annual.index[0]]

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/epw.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/ladybug_extension/epw.py
@@ -1074,12 +1074,12 @@ def seasonality_from_temperature_timeseries(
         dbt.drop((2, 29), axis=0, inplace=True)
     except KeyError:
         pass
-    dbt.index = pd.date_range("2017-01-01 00:00:00", freq="60T", periods=8760)
+    dbt.index = pd.date_range("2017-01-01 00:00:00", freq="60min", periods=8760)
     dbt.name = "dbt"
 
     # prepare a 3-year dataset using the aggregate year from the input data and drop leap days if included
     dbt_3year = pd.Series(
-        index=pd.date_range("2016-01-01 00:00:00", freq="60T", periods=len(dbt) * 3),
+        index=pd.date_range("2016-01-01 00:00:00", freq="60min", periods=len(dbt) * 3),
         data=np.array([[i] * 3 for i in dbt.values]).T.flatten(),
     )
 
@@ -1709,7 +1709,7 @@ def longest_day(epw: EPW) -> datetime:
     The longest day in the year associated with this epw object."""
 
     sunpath = Sunpath.from_location(epw.location)
-    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="1T")
+    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="1min")
     suns = [sunpath.calculate_sun_from_date_time(i) for i in idx][:-1]
 
     s = pd.Series([i.altitude for i in suns], index=idx[:-1])
@@ -1722,7 +1722,7 @@ def shortest_day(epw: EPW) -> datetime:
     The shortest day in the year associated with this epw object."""
 
     sunpath = Sunpath.from_location(epw.location)
-    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="1T")
+    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="1min")
     suns = [sunpath.calculate_sun_from_date_time(i) for i in idx][:-1]
 
     s = pd.Series([i.altitude for i in suns], index=idx[:-1])

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_diurnal.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_diurnal.py
@@ -71,7 +71,7 @@ def diurnal(
 
     # resample to hourly to ensuure hour alignment
     # TODO - for now we only resample to hourly, but this could be made more flexible by allowing any subset of period
-    series = series.resample("H").mean()
+    series = series.resample("h").mean()
 
     # remove nan/inf
     series = series.replace([-np.inf, np.inf], np.nan).dropna()

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_misc.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_misc.py
@@ -474,7 +474,7 @@ def solar_elevation_azimuth(location: Location, ax: plt.Axes = None) -> plt.Axes
         ax = plt.gca()
 
     sp = Sunpath.from_location(location)
-    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="10T")
+    idx = pd.date_range("2017-01-01 00:00:00", "2018-01-01 00:00:00", freq="10min")
     suns = [sp.calculate_sun_from_date_time(i) for i in idx]
     a = pd.DataFrame(index=idx)
     a["altitude"] = [i.altitude for i in suns]

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_sunpath.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/plot/_sunpath.py
@@ -69,7 +69,7 @@ def sunpath(
     day_suns = []
     for month in [6, 9, 12]:
         date = pd.to_datetime(f"2017-{month:02d}-21")
-        day_idx = pd.date_range(date, date + pd.Timedelta(hours=24), freq="1T")
+        day_idx = pd.date_range(date, date + pd.Timedelta(hours=24), freq="1min")
         _ = []
         for idx in day_idx:
             s = sunpath_obj.calculate_sun_from_date_time(idx)

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/solar.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/solar.py
@@ -453,7 +453,7 @@ class Solar:
         df = remove_leap_days(self.df)
 
         grouped = df.groupby([df.index.month, df.index.day, df.index.hour]).mean()
-        index = pd.date_range("2017-01-01", periods=8760, freq="60T")
+        index = pd.date_range("2017-01-01", periods=8760, freq="60min")
         grouped.set_index(index, inplace=True)
 
         return Wea.from_annual_values(

--- a/LadybugTools_Engine/Python/tests/test_helpers.py
+++ b/LadybugTools_Engine/Python/tests/test_helpers.py
@@ -525,7 +525,7 @@ def test_remove_leap_days():
 def test_month_hour_binned_series():
     """_"""
     s = pd.Series(
-        index=pd.date_range(start="2017-01-01 00:00:00", freq="60T", periods=8760),
+        index=pd.date_range(start="2017-01-01 00:00:00", freq="60min", periods=8760),
         data=range(8760),
     )
 
@@ -545,7 +545,7 @@ def test_month_hour_binned_series():
         month_hour_binned_series(
             pd.Series(
                 index=pd.date_range(
-                    start="2017-01-01 00:00:00", freq="60T", periods=5000
+                    start="2017-01-01 00:00:00", freq="60min", periods=5000
                 ),
                 data=range(5000),
             )
@@ -556,7 +556,7 @@ def test_month_hour_binned_series():
         month_hour_binned_series(
             pd.Series(
                 index=pd.date_range(
-                    start="2017-01-01 00:00:00", freq="120T", periods=8760 * 3
+                    start="2017-01-01 00:00:00", freq="120min", periods=8760 * 3
                 ),
                 data=range(8760),
             )

--- a/LadybugTools_Engine/Python/tests/test_ladybug_extension/test_datacollection.py
+++ b/LadybugTools_Engine/Python/tests/test_ladybug_extension/test_datacollection.py
@@ -11,7 +11,7 @@ from .. import EPW_OBJ
 SERIES_GOOD = pd.Series(
     data=EPW_OBJ.dry_bulb_temperature.values,
     name="Dry Bulb Temperature (C)",
-    index=pd.date_range("2007-01-01 00:30:00", freq="60T", periods=8760),
+    index=pd.date_range("2007-01-01 00:30:00", freq="60min", periods=8760),
 )
 
 

--- a/LadybugTools_Engine/Python/tests/test_plot.py
+++ b/LadybugTools_Engine/Python/tests/test_plot.py
@@ -250,7 +250,7 @@ def test_heatmap():
         heatmap(
             pd.Series(
                 np.random.random(21000),
-                index=pd.date_range("2000-01-01", periods=21000, freq="H"),
+                index=pd.date_range("2000-01-01", periods=21000, freq="h"),
             )
         ),
         plt.Axes,


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #208 

<!-- Add short description of what has been fixed -->
replaced deprecated `freq` arguments "T" and "H" with "min" and "h"

### Test files
<!-- Link to test files to validate the proposed changes -->
run the `run_tests.bat` file after compiling, and see that all the unit tests pass, and no warnings are produced.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->