### PR TITLE
Fixed python Materials enum invalid keys

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
@@ -2,6 +2,7 @@
 """
 
 # pylint: disable=E0401
+import re
 from difflib import get_close_matches
 from pathlib import Path
 from enum import Enum
@@ -178,8 +179,15 @@ def get_material(material_identifier: str) -> _EnergyMaterialOpaqueBase:
                 f"Unknown material name: '{material_identifier}'. Did you mean {possible_materials}"
             ) from exc
 
+def get_identifier(material_identifier: str) -> str:
+    keep_characters = r"[^A-Za-z0-9_]"
+
+    if any([material_identifier.startswith(str(num)) for num in range(10)]):
+        material_identifier = f"_{material_identifier}"
+
+    return re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
 
 Materials = Enum(
     "Materials",
-    {sanitise_string(material.identifier): material for material in materials()},
+    {get_identifier(material.identifier): material for material in materials()},
 )

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
@@ -180,13 +180,23 @@ def get_material(material_identifier: str) -> _EnergyMaterialOpaqueBase:
             ) from exc
 
 def get_identifier(material_identifier: str) -> str:
+    """Get the enum-valid identifier for a given material identifier.
+
+    Args:
+        material_identifier (str): The identifier to sanitise.
+
+    Returns:
+        str: The sanitised material identifier.
+    """
     keep_characters = r"[^A-Za-z0-9_]"
 
+    material_identifier = re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
+    
     # prepend `Material_` to identifiers which start with a number
-    if any([material_identifier.startswith(str(num)) for num in range(10)]):
+    if re.match("^\d", material_identifier):
         material_identifier = f"Material_{material_identifier}"
 
-    return re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
+    return material_identifier
 
 Materials = Enum(
     "Materials",

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
@@ -182,8 +182,9 @@ def get_material(material_identifier: str) -> _EnergyMaterialOpaqueBase:
 def get_identifier(material_identifier: str) -> str:
     keep_characters = r"[^A-Za-z0-9_]"
 
+    # prepend `Thickness_` to identifiers which start with a number as the number references the thickness
     if any([material_identifier.startswith(str(num)) for num in range(10)]):
-        material_identifier = f"_{material_identifier}"
+        material_identifier = f"Thickness_{material_identifier}"
 
     return re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
 

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
@@ -182,9 +182,9 @@ def get_material(material_identifier: str) -> _EnergyMaterialOpaqueBase:
 def get_identifier(material_identifier: str) -> str:
     keep_characters = r"[^A-Za-z0-9_]"
 
-    # prepend `Thickness_` to identifiers which start with a number as the number references the thickness
+    # prepend `Material_` to identifiers which start with a number
     if any([material_identifier.startswith(str(num)) for num in range(10)]):
-        material_identifier = f"Thickness_{material_identifier}"
+        material_identifier = f"Material_{material_identifier}"
 
     return re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #213 

<!-- Add short description of what has been fixed -->
When creating the enum, instead of calling `sanitise_string`, it calls the new method `get_identifier` which behaves similarly to sanitise_string, except it also excludes `-`, `.` and prepends `_` when the identifier starts with a number.

### Test files
<!-- Link to test files to validate the proposed changes -->
try to get a material using the enum as follows:
```
from ladybugtools_toolkit.external_comfort.material import Materials
Materials.Material_12_in_Normalweight_Concrete_Floor
```
should return the material given properly.

Ensure that the Materials enum contains all the materials. (can tab through and compare to latest alpha/beta)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
