### PR TITLE
Features for various wind methods

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/helpers.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/helpers.py
@@ -1037,6 +1037,7 @@ def scrape_openmeteo(
     end_date: datetime | str,
     variables: tuple[OpenMeteoVariable] = None,
     convert_units: bool = False,
+    remove_leapyears: bool = False,
 ) -> pd.DataFrame:
     """Obtain historic hourly data from Open-Meteo.
     https://open-meteo.com/en/docs/historical-weather-api
@@ -1054,6 +1055,8 @@ def scrape_openmeteo(
             A list of variables to query. If None, then all variables will be queried.
         convert_units (bool, optional):
             Convert units output into more common units, and rename headers accordingly.
+        remove_leapyears (bool, optional):
+            Whether or not to remove occurences of February 29th from the scraped data.
 
     Note:
         This method saves the data to a local cache, and will return the cached data if it is less
@@ -1141,6 +1144,9 @@ def scrape_openmeteo(
 
     # combine data
     df = pd.concat(available_data, axis=1)
+
+    if remove_leapyears:
+        df = df[~((df.index.month == 2) & (df.index.day == 29))]
 
     if not convert_units:
         return df

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
@@ -1587,6 +1587,7 @@ class Wind:
         self,
         ax: plt.Axes = None,
         show_values: bool = False,
+        show_arrows: bool = True,
         **kwargs,
     ) -> plt.Axes:
         """Create a plot showing the annual wind speed and direction bins
@@ -1597,6 +1598,8 @@ class Wind:
                 The axes to plot on. If None, the current axes will be used.
             show_values (bool, optional):
                 Whether to show values in the cells. Defaults to False.
+            show_arrows (bool, optional):
+                Whether to show the directional arrows on each patch.
             **kwargs:
                 Additional keyword arguments to pass to the pcolor function.
 
@@ -1640,17 +1643,18 @@ class Wind:
         _x = -np.sin(np.deg2rad(_wind_directions.values))
         _y = -np.cos(np.deg2rad(_wind_directions.values))
         direction_matrix = angle_from_north([_x, _y])
-        ax.quiver(
-            np.arange(1, 13, 1) - 0.5,
-            np.arange(0, 24, 1) + 0.5,
-            _x * _wind_speeds.values / 2,
-            _y * _wind_speeds.values / 2,
-            pivot="mid",
-            fc="white",
-            ec="black",
-            lw=0.5,
-            alpha=0.5,
-        )
+        if (show_arrows):
+            ax.quiver(
+                np.arange(1, 13, 1) - 0.5,
+                np.arange(0, 24, 1) + 0.5,
+                _x * _wind_speeds.values / 2,
+                _y * _wind_speeds.values / 2,
+                pivot="mid",
+                fc="white",
+                ec="black",
+                lw=0.5,
+                alpha=0.5,
+            )
 
         if show_values:
             for _xx, col in enumerate(_wind_directions.values.T):
@@ -1766,6 +1770,7 @@ class Wind:
         other_data: list[float] = None,
         other_bins: list[float] = None,
         colors: list[str | tuple[float] | Colormap] = None,
+        title: str = None,
         legend: bool = True,
         ylim: tuple[float] = None,
         label: bool = False,
@@ -1785,6 +1790,8 @@ class Wind:
             colors: (str | tuple[float] | Colormap, optional):
                 A list of colors to use for the other bins. May also be a colormap. Defaults to the colors used for
                 Beaufort wind comfort categories.
+            title (str, optional):
+                title to display above the plot. Defaults to the source of this wind object.
             legend (bool, optional):
                 Set to False to remove the legend. Defaults to True.
             ylim (tuple[float], optional):
@@ -1837,7 +1844,10 @@ class Wind:
         hist_ax.bar(np.array([1]), np.array([1]))
         # HACK end
 
-        ax.set_title(textwrap.fill(f"{self.source}", 75))
+        if title is None or title == "":
+            ax.set_title(textwrap.fill(f"{self.source}", 75))
+        else:
+            ax.set_title(title)
 
         theta_width = np.deg2rad(360 / directions)
         patches = []


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #210 
Closes #211 
Closes #212 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Using Jupyter, test creating wind roses and wind matrices, showing/not showing arrows on matrices, and setting the title on wind roses.
Test the scrape_openmeteo method including and excluding leap year data

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
* Added boolean option to disable directional arrows when using `Wind.plot_windmatrix()`
* Added ability to set the title when using `Wind.plot_windrose()`
* Added ability to exclude leap year days when using `helpers.scrape_openmeteo()`

### Additional comments
<!-- As required -->