### PR TITLE
Fixed fully enclosed typologies

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_shelterbase.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_shelterbase.py
@@ -289,7 +289,7 @@ class Shelter:
     def from_adjacent_wall(
         cls,
         distance_from_wall: float = 1,
-        wall_height: float = 2,
+        wall_height: float = 3.5,
         wall_length: float = 2,
         wind_porosity: list[float] = (0,) * 8760,
         radiation_porosity: list[float] = (0,) * 8760,

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/typology.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/typology.py
@@ -22,7 +22,7 @@ class Typologies(Enum):
             Shelter.from_adjacent_wall(angle=90),
             Shelter.from_adjacent_wall(angle=180),
             Shelter.from_adjacent_wall(angle=270),
-            Shelter.from_overhead_circle(height_above_ground=2),
+            Shelter.from_overhead_circle(),
         ],
     )
     ENCLOSED_POROUS = Typology(
@@ -32,7 +32,7 @@ class Typologies(Enum):
             Shelter.from_adjacent_wall(angle=90).set_porosity(0.5),
             Shelter.from_adjacent_wall(angle=180).set_porosity(0.5),
             Shelter.from_adjacent_wall(angle=270).set_porosity(0.5),
-            Shelter.from_overhead_circle(height_above_ground=2).set_porosity(0.5),
+            Shelter.from_overhead_circle().set_porosity(0.5),
         ],
     )
     SKY_SHELTER = Typology(

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/typology.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/typology.py
@@ -22,7 +22,7 @@ class Typologies(Enum):
             Shelter.from_adjacent_wall(angle=90),
             Shelter.from_adjacent_wall(angle=180),
             Shelter.from_adjacent_wall(angle=270),
-            Shelter.from_overhead_circle(),
+            Shelter.from_overhead_circle(height_above_ground=2),
         ],
     )
     ENCLOSED_POROUS = Typology(
@@ -32,7 +32,7 @@ class Typologies(Enum):
             Shelter.from_adjacent_wall(angle=90).set_porosity(0.5),
             Shelter.from_adjacent_wall(angle=180).set_porosity(0.5),
             Shelter.from_adjacent_wall(angle=270).set_porosity(0.5),
-            Shelter.from_overhead_circle().set_porosity(0.5),
+            Shelter.from_overhead_circle(height_above_ground=2).set_porosity(0.5),
         ],
     )
     SKY_SHELTER = Typology(


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #225 

<!-- Add short description of what has been fixed -->
from_adjacent_wall has been updated to make walls of height 3.5m, to fully enclose with default sky shelters

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
* Updated `Shelter.from_adjacent_wall()` default height to 3.5m

### Additional comments
<!-- As required -->