### PR TITLE
Fixing failing nuget package production

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.LadybugTools.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.LadybugTools.nuspec
@@ -28,9 +28,7 @@
     <file src="licence/licence.txt" target="" />
     <file src="images/icon.png" target="" />
     <file src="docs/readme.md" target="" />
-    <!--lib\**\* is a workaround for contentfiles not including dll files-->
-    <file src="lib\**\*" target="lib" />
-	<file src="C:\ProgramData\BHoM\Extensions\PythonCode\LadybugTools_Toolkit\src\ladybugtools_toolkit\bhom\wrapped\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonCode\LadybugTools_Toolkit\src\ladybugtools_toolkit\bhom\wrapped"/>
-	<file src="C:\ProgramData\BHoM\Extensions\PythonCode\LadybugTools_Toolkit\src\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonEnvironment\Lib\site-packages" />
+    <file src="C:\ProgramData\BHoM\Extensions\PythonCode\LadybugTools_Toolkit\src\ladybugtools_toolkit\bhom\wrapped\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonCode\LadybugTools_Toolkit\src\ladybugtools_toolkit\bhom\wrapped"/>
+    <file src="C:\ProgramData\BHoM\Extensions\PythonCode\LadybugTools_Toolkit\src\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonEnvironment\Lib\site-packages" />
   </files>
 </package>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #230

See issue for more details on the problem and the solution.  Despite the comment found in the nuspec file stating that `<file src="lib\**\*" target="lib" />` was a workaround for contentfiles not including dll files, I got the same exact nuspec by deleting that line than by deleting the dlls added by the bot. 


### Test files
As of right now, there are other problems in the bot code that prevent to generate a successful nuget package. So this PR only solves the part of the error that is caused by the content of this repo. 
This makes it hard to test the changes made here in isolation but @Tom-Kingstone did receive a nuget package that included the changes made in this PR and confirmed it was working successfully. So that should be enough to merge this PR for now and keep monitoring once the additional bug have been fixed on the bot side.
