### PR TITLE
Fix incorrect MRT calculation for some epws

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
@@ -283,10 +283,12 @@ class Typology:
         for sun_exp, sky_exp, shaded, unshaded in list(
             zip(*[_sun_exposure, _sky_exposure, shaded_mrt.values, unshaded_mrt.values])
         ):
-            if sun_exp:
-                mrts.append(np.interp(sun_exp, [0, 1], [shaded, unshaded]))
-            else:
+            if pd.isna(sun_exp):
+                # The sun isn't above the horizon (sun_exp is null), therefore it's night so use the sky view.
                 mrts.append(np.interp(sky_exp, [0, 1], [shaded, unshaded]))
+            else:
+                # The sun is above the horizon and is fully or partially visible.
+                mrts.append(np.interp(sun_exp, [0, 1], [shaded, unshaded]))
 
         # Fill any gaps where sun-visible/sun-occluded values are missing
         mrt_series = pd.Series(


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #232 

<!-- Add short description of what has been fixed -->
Changes made in accordance with linked issue.

If sun exposure is null, then use sky exposure instead when calculating shaded and unshaded MRT.

### Test files
<!-- Link to test files to validate the proposed changes -->
Verify that MRT is being calculated properly (@tg359 has an epw that caused this issue before)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->