### PR TITLE
Added `Wet Bulb Temperature` to EPW Keys

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/diurnal.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/diurnal.py
@@ -9,6 +9,7 @@ def diurnal(epw_file, return_file: str, data_type_key="Dry Bulb Temperature", co
     try:
         from ladybug.epw import EPW, AnalysisPeriod
         from ladybugtools_toolkit.ladybug_extension.datacollection import collection_to_series
+        from ladybugtools_toolkit.ladybug_extension.epw import wet_bulb_temperature
         from ladybugtools_toolkit.plot._diurnal import diurnal
         from ladybug.datacollection import HourlyContinuousCollection
         from ladybugtools_toolkit.plot.utilities import figure_to_base64
@@ -16,13 +17,15 @@ def diurnal(epw_file, return_file: str, data_type_key="Dry Bulb Temperature", co
         import matplotlib.pyplot as plt
         
         epw = EPW(epw_file)
-        data_type_key = data_type_key.replace("_"," ")
-        coll = HourlyContinuousCollection.from_dict([a for a in epw.to_dict()["data_collections"] if a["header"]["data_type"]["name"] == data_type_key][0])
-        fig = diurnal(collection_to_series(coll), title=title, period=period, color=color).get_figure()
         
+        if data_type_key == "Wet Bulb Temperature":
+            coll = wet_bulb_temperature(epw)
+        else:
+            coll = HourlyContinuousCollection.from_dict([a for a in epw.to_dict()["data_collections"] if a["header"]["data_type"]["name"] == data_type_key][0])
         
+        fig = diurnal(collection_to_series(coll),title=title, period=period, color=color).get_figure()
         return_dict = {"data": collection_metadata(coll)}
-
+        
         if save_path == None or save_path == "":
             base64 = figure_to_base64(fig, html=False)
             return_dict["figure"] = base64

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
@@ -14,14 +14,21 @@ def heatmap(epw_file: str, data_type_key: str, colour_map: str, return_file: str
         from ladybugtools_toolkit.plot._heatmap import heatmap
         from ladybugtools_toolkit.ladybug_extension.datacollection import collection_to_series
         from ladybugtools_toolkit.bhom.wrapped.metadata.collection import collection_metadata
+        from ladybugtools_toolkit.ladybug_extension.epw import wet_bulb_temperature
         from ladybugtools_toolkit.plot.utilities import figure_to_base64
         import matplotlib.pyplot as plt
 
         if colour_map not in plt.colormaps():
             colour_map = "YlGnBu"
 
+
         epw = EPW(epw_file)
-        coll = HourlyContinuousCollection.from_dict([a for a in epw.to_dict()["data_collections"] if a["header"]["data_type"]["name"] == data_type_key][0])
+        
+        if data_type_key == "Wet Bulb Temperature":
+            coll = wet_bulb_temperature(epw)
+        else:
+            coll = HourlyContinuousCollection.from_dict([a for a in epw.to_dict()["data_collections"] if a["header"]["data_type"]["name"] == data_type_key][0])
+        
         fig = heatmap(collection_to_series(coll), cmap=colour_map).get_figure()
 
         return_dict = {}

--- a/LadybugTools_oM/Enum/EPWKeys.cs
+++ b/LadybugTools_oM/Enum/EPWKeys.cs
@@ -74,6 +74,8 @@ namespace BH.oM.LadybugTools
         [DisplayText("Total Sky Cover")]
         TotalSkyCover,
         Visibility,
+        [DisplayText("Wet Bulb Temperature")]
+        WetBulbTemperature,
         [DisplayText("Wind Direction")]
         WindDirection,
         [DisplayText("Wind Speed")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #229 

<!-- Add short description of what has been fixed -->
Updated the enum, and added logic to wrapped methods to handle calculating a wet bulb temperature collection from the epw file.

### Test files
<!-- Link to test files to validate the proposed changes -->
[LBT_229_test.zip](https://github.com/user-attachments/files/16468973/LBT_229_test.zip)
Check that the wet bulb temperature is correctly calculated, and check that normal epw keys aren't broken



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->