### PR TITLE
Fix failing unit test

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/material.py
@@ -193,7 +193,7 @@ def get_identifier(material_identifier: str) -> str:
     material_identifier = re.sub(keep_characters, "_", material_identifier).replace("__", "_").rstrip()
     
     # prepend `Material_` to identifiers which start with a number
-    if re.match("^\d", material_identifier):
+    if re.match(r"^\d", material_identifier):
         material_identifier = f"Material_{material_identifier}"
 
     return material_identifier

--- a/LadybugTools_Engine/Python/tests/test_wind.py
+++ b/LadybugTools_Engine/Python/tests/test_wind.py
@@ -181,7 +181,8 @@ def test_bin_data():
 
 def test_prevailing():
     """_"""
-    assert TEST_WIND.prevailing()[0] == (355.0, 5.0)
+    assert TEST_WIND.prevailing(ignore_calm=False)[0] == (355.0, 5.0)
+    assert TEST_WIND.prevailing()[0] == (205.0, 215.0)
 
 
 def test_probabilities():


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #242

<!-- Add short description of what has been fixed -->
Fixed unit test for Wind.prevailing()
also fixed an invalid escape sequence.

### Test files
<!-- Link to test files to validate the proposed changes -->
run `run_tests.bat` and ensure that all tests are passing.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->