### PR TITLE
Change matplotlib backend to GUI-less for wrapped methods

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/directional_solar_radiation.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/directional_solar_radiation.py
@@ -4,6 +4,7 @@ import argparse
 import traceback
 from pathlib import Path
 import os
+import matplotlib
 
 def directional_solar_radiation(epw_file, azimuths, altitudes, ground_reflectance, irradiance_type, isotropic, analysis_period, title, save_path):
     try:
@@ -114,5 +115,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     os.environ["TQDM_DISABLE"] = "1" # set an environment variable so that progress bars are disabled for the simulation process
+    matplotlib.use("Agg")
     directional_solar_radiation(args.epw_file, args.azimuths, args.altitudes, args.ground_reflectance, args.irradiance_type, args.isotropic, args.analysis_period, args.title, args.save_path)
     del os.environ["TQDM_DISABLE"] # unset the env variable

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/diurnal.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/diurnal.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import traceback
 from pathlib import Path
+import matplotlib
 
 def diurnal(epw_file, return_file: str, data_type_key="Dry Bulb Temperature", color="#000000", title=None, period="monthly", save_path = None):
     try:
@@ -98,4 +99,5 @@ if __name__ == "__main__":
         )
 
     args = parser.parse_args()
+    matplotlib.use("Agg")
     diurnal(args.epw_file, args.return_file, args.data_type_key, args.colour, args.title, args.period, args.save_path)

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/heatmap.py
@@ -4,7 +4,7 @@ import argparse
 import traceback
 from pathlib import Path
 import json
-
+import matplotlib
 
 def heatmap(epw_file: str, data_type_key: str, colour_map: str, return_file: str, save_path:str = None) -> None:
     """Create a CSV file version of an EPW."""
@@ -96,4 +96,5 @@ if __name__ == "__main__":
         )
 
     args = parser.parse_args()
+    matplotlib.use("Agg")
     heatmap(args.epw_file, args.data_type_key, args.colour_map, args.return_file, args.save_path)

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/sunpath.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/sunpath.py
@@ -3,6 +3,7 @@
 import argparse
 import traceback
 from pathlib import Path
+import matplotlib
 
 def sun_path(epw_file, analysis_period, size, return_file: str, save_path):
     try:
@@ -84,4 +85,5 @@ if __name__ == "__main__":
         )
 
     args = parser.parse_args()
+    matplotlib.use("Agg")
     sun_path(args.epw_file, args.analysis_period, args.size, args.return_file, args.save_path)

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/utci_heatmap.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/utci_heatmap.py
@@ -4,7 +4,7 @@ import argparse
 import traceback
 from pathlib import Path
 from unittest.util import _MIN_COMMON_LEN
-
+import matplotlib
 
 def utci_heatmap(epw_file:str,
             json_file:str,
@@ -114,4 +114,5 @@ if __name__ == "__main__":
 
 
     args = parser.parse_args()
+    matplotlib.use("Agg")
     utci_heatmap(args.epw_path, args.json_args, args.return_file, args.wind_speed_multiplier, args.save_path)

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/windrose.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/bhom/wrapped/plot/windrose.py
@@ -3,7 +3,7 @@
 import argparse
 import traceback
 from pathlib import Path
-
+import matplotlib
 
 def windrose(epw_file: str, analysis_period: str, colour_map: str, bins: int, return_file: str, save_path: str = None) -> None:
     """Method to wrap for creating wind roses from epw files."""
@@ -98,4 +98,5 @@ if __name__ == "__main__":
         )
 
     args = parser.parse_args()
+    matplotlib.use("Agg")
     windrose(args.epw_file, args.analysis_period, args.colour_map, args.bins, args.return_file, args.save_path)

--- a/LadybugTools_oM/MetaData/SunData.cs
+++ b/LadybugTools_oM/MetaData/SunData.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using BH.oM.Base.Attributes;
 using System;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ using System.Text;
 namespace BH.oM.LadybugTools
 {
     [NoAutoConstructor]
-    public class SunData
+    public class SunData : IObject
     {
         [Description("The azimuth angle at sunrise in degrees. Sunrise is defined as the time at which the sun is first visible above the horizon, ignoring atmospheric effects.")]
         public virtual double SunriseAzimuth { get; set; } = double.NaN;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #241 

<!-- Add short description of what has been fixed -->
Changed matplotlib backend for all wrapped methods where plots are generated to use a non-GUI backend (`Agg`)
Also added `IObject` interface to SunData so that it can be serialised using the BHoM serialiser properly.

### Test files
<!-- Link to test files to validate the proposed changes -->
Test that running each of the execute commands for the wrapped methods still produces the plots as expected.
[LBT 241.zip](https://github.com/user-attachments/files/16931970/LBT.241.zip)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->