### PR TITLE
Height above ground in the wind class now defaults to 10.0 meters

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
@@ -68,7 +68,7 @@ class Wind:
     wind_speeds: list[float]
     wind_directions: list[float]
     datetimes: list[datetime] | pd.DatetimeIndex
-    height_above_ground: float
+    height_above_ground: float = 10.0
     source: str = None
 
     def __post_init__(self):


### PR DESCRIPTION

 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #277

<!-- Add short description of what has been fixed -->

Previously no default value for heights above ground was provided. 
Height above ground in the wind class now defaults to 10.0 meters

### Test files
<!-- Link to test files to validate the proposed changes -->
run python automated testing batch file

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->