### PR TITLE
Handle NoneType in plot_windmatrix to Prevent Errors

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
@@ -1677,7 +1677,7 @@ class Wind:
 
         title = self.source if self.source is not None else ""
         title += f'\n{kwargs.pop("title", None)}'
-        ax.set_title(textwrap.fill(f"{self.source}", 75))
+        ax.set_title(textwrap.fill(f"{title}", 75))
 
         df = self.wind_matrix(other_data=other_data)
         _other_data = df["other"]

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
@@ -1675,7 +1675,7 @@ class Wind:
         if other_data is None:
             other_data = self.ws
 
-        title = self.source
+        title = self.source if self.source is not None else "title"
         title += f'\n{kwargs.pop("title", None)}'
         ax.set_title(textwrap.fill(f"{self.source}", 75))
 

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/wind.py
@@ -1675,7 +1675,7 @@ class Wind:
         if other_data is None:
             other_data = self.ws
 
-        title = self.source if self.source is not None else "title"
+        title = self.source if self.source is not None else ""
         title += f'\n{kwargs.pop("title", None)}'
         ax.set_title(textwrap.fill(f"{self.source}", 75))
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #276 

<!-- Add short description of what has been fixed -->
plot_windmatrix failed if self.source == None. 
Added a if-loop to handle the NoneType in plot_windmatrix to prevent errors when creating the plot title.

### Test files
<!-- Link to test files to validate the proposed changes -->
run python automated testing batch file 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->