### PR TITLE
Fix warning when inputting a valid matplotlib colourmap to commands

### DIFF
--- a/LadybugTools_Adapter/Convert/ToColourMap.cs
+++ b/LadybugTools_Adapter/Convert/ToColourMap.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.LadybugTools
                 FieldInfo field = item.GetType().GetField(item.ToString());
                 DisplayTextAttribute[] array = field.GetCustomAttributes(typeof(DisplayTextAttribute), inherit: false) as DisplayTextAttribute[];
                 if (array != null && array.Length > 0)
-                    if (array.First().ToString().ToLower() == colourMap.ToLower())
+                    if (array.First().Text.ToLower() == colourMap.ToLower())
                         return item;
             }
             BH.Engine.Base.Compute.RecordError($"Could not convert the input string: {colourMap} to a colourmap.");

--- a/LadybugTools_Adapter/Convert/ToColourMap.cs
+++ b/LadybugTools_Adapter/Convert/ToColourMap.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.LadybugTools
 
             foreach (ColourMap item in Enum.GetValues(typeof(ColourMap)))
             {
-                if (item.FromColourMap() == colourMap)
+                if (item.FromColourMap().ToLower() == colourMap.ToLower())
                     return item;
 
                 if (item.ToString().ToLower() == colourMap.ToLower())

--- a/LadybugTools_Adapter/Convert/ToColourMap.cs
+++ b/LadybugTools_Adapter/Convert/ToColourMap.cs
@@ -42,15 +42,17 @@ namespace BH.Adapter.LadybugTools
 
             foreach (ColourMap item in Enum.GetValues(typeof(ColourMap)))
             {
-                List<string> possibleValues = new List<string>();
-                possibleValues.Add(item.ToString().ToLower());
+                if (item.FromColourMap() == colourMap)
+                    return item;
+
+                if (item.ToString().ToLower() == colourMap.ToLower())
+                    return item;
+
                 FieldInfo field = item.GetType().GetField(item.ToString());
                 DisplayTextAttribute[] array = field.GetCustomAttributes(typeof(DisplayTextAttribute), inherit: false) as DisplayTextAttribute[];
                 if (array != null && array.Length > 0)
-                    possibleValues.Add(array.First().Text.ToLower());
-
-                if (possibleValues.Any(x => x == colourMap.ToLower()))
-                    return item;
+                    if (array.First().ToString().ToLower() == colourMap.ToLower())
+                        return item;
             }
             BH.Engine.Base.Compute.RecordError($"Could not convert the input string: {colourMap} to a colourmap.");
             return ColourMap.Undefined;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #288 

<!-- Add short description of what has been fixed -->
Improved check that converts a sring to a colourmap enum value.

### Test files
<!-- Link to test files to validate the proposed changes -->
check by running the SolarRadiation plot with default values, there should be no warning about colourmaps in the execute component.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->