### PR TITLE
Fix error where setting dbt and relative humidity for an external comfort would break wind speed

### DIFF
--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
@@ -172,6 +172,7 @@ class Typology:
     def wind_speed(self, epw: EPW) -> list[float]:
         """Direct access to "wind_speed" method for this typology object."""
         #multiply wind speed by multiplier
+        epw.wind_speed
         wind_speed = epw._data[21]
         epw._data[21] = epw.wind_speed * self.wind_speed_multiplier
 

--- a/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
+++ b/LadybugTools_Engine/Python/src/ladybugtools_toolkit/external_comfort/_typologybase.py
@@ -172,7 +172,7 @@ class Typology:
     def wind_speed(self, epw: EPW) -> list[float]:
         """Direct access to "wind_speed" method for this typology object."""
         #multiply wind speed by multiplier
-        epw.wind_speed
+        epw.wind_speed #do not remove this as long as the _data[21] exists below, otherwise an index error occurs as the wind data does not get loaded in some cases.
         wind_speed = epw._data[21]
         epw._data[21] = epw.wind_speed * self.wind_speed_multiplier
 

--- a/LadybugTools_Engine/Python/tests/test_external_comfort/test_externalcomfort.py
+++ b/LadybugTools_Engine/Python/tests/test_external_comfort/test_externalcomfort.py
@@ -5,9 +5,11 @@ import pandas as pd
 import pytest
 from ladybugtools_toolkit.external_comfort.externalcomfort import ExternalComfort
 from ladybugtools_toolkit.external_comfort.typology import Typologies
+from ladybug.datacollection import HourlyContinuousCollection
 
 from .test_simulate import TEST_SIMULATION_RESULT
 from .test_typology import TEST_TYPOLOGY
+from .. import EPW_OBJ
 
 TEST_EXTERNAL_COMFORT = ExternalComfort(
     simulation_result=TEST_SIMULATION_RESULT, typology=TEST_TYPOLOGY
@@ -122,3 +124,9 @@ def test_plot_mrt_heatmap():
 
     assert isinstance(TEST_EXTERNAL_COMFORT.plot_mrt_heatmap(), plt.Axes)
     plt.close("all")
+
+def test_set_all_but_wind_speed():
+    """Test that the wind speed method for getting the typology wind speed works correctly when dbt and rh are set."""
+    temp_ec_test = ExternalComfort(TEST_SIMULATION_RESULT, typology=TEST_TYPOLOGY, dry_bulb_temperature=EPW_OBJ.dry_bulb_temperature, relative_humidity=EPW_OBJ.relative_humidity)
+    assert isinstance(temp_ec_test, ExternalComfort)
+    assert isinstance(temp_ec_test.wind_speed, HourlyContinuousCollection)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #318 

<!-- Add short description of what has been fixed -->
see the linked issue, the fix was to access the wind speed for the given epw before trying to do things with _data, which would normally happen in the case where dbt or rh are unset, but doesn't when they are.

### Test files
<!-- Link to test files to validate the proposed changes -->
run the unit test, and @CKBoulter has a case where this was occurring on a jupyter script

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->